### PR TITLE
Fix #15 by opening the browser when the inspector task is executed

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ var es = require('event-stream'),
   merge = require('merge'),
   debugServer = require('node-inspector/lib/debug-server'),
   Config = require('node-inspector/lib/config'),
-  packageJson = require('node-inspector/package.json');
+  packageJson = require('node-inspector/package.json'),
+  os = require('os'),
+  open = require('open');
 
 var PluginError = gutil.PluginError;
 var config = new Config([]);
@@ -36,7 +38,15 @@ var nodeInspector = function(opt) {
     });
 
     debugServer.on('listening', function() {
-      log(colors.green('Visit', this.address().url, 'to start debugging.'));
+      log(colors.blue('Opening', colors.green(this.address().url), 'in Chrome. It may take a few seconds to load the inspector...'));
+
+      // Find out which OS the user is in... Open in the specific browser...
+      var chrome = os.platform() === 'linux' ? 'google-chrome' : (
+        os.platform() === 'darwin' ? 'google chrome' : (
+        os.platform() === 'win32' ? 'chrome' : 'firefox'));
+
+      // Open the url
+      open(this.address().url, chrome);
     });
 
     debugServer.on('close', function() {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   },
   "homepage": "https://github.com/koemei/gulp-node-inspector",
   "dependencies": {
-    "gulp-util": "^3.0.2",
     "event-stream": "^3.2.2",
+    "gulp-util": "^3.0.2",
+    "merge": "^1.2.0",
     "node-inspector": "^0.10.1",
-    "merge": "^1.2.0"
+    "open": "0.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-node-inspector",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Run node inspector from your gulp build.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This commit fixes #15 by using the module open, which will open a brower
with a given URL. Based on
https://github.com/stevelacy/gulp-open#optionsapp, Chrome's binary is
different on each OS, so the switch, falling back to 'firefox' in case
of a different OS.

*	modified:   index.js
- Adding the modules OS and Open.
- Making the log message a bit more readable.
- Finding out which binary to use
- Opening the URL.

*	modified:   package.json
- Updated with "npm install --save open"